### PR TITLE
fix(bug): a sorting didn't work in the users table

### DIFF
--- a/src/app_layer/providers/apollo-provider.tsx
+++ b/src/app_layer/providers/apollo-provider.tsx
@@ -41,7 +41,7 @@ function makeClient() {
         Query: {
           fields: {
             getUsers: {
-              keyArgs: ['statusFilter', 'searchTerm', 'pageNumber'],
+              keyArgs: ['statusFilter', 'searchTerm', 'pageNumber', 'sortBy', 'sortDirection'],
               read(existing: GetUsersListQuery['getUsers'], options) {
                 // возврат undefined сигнализирует о том, что Apollo Client
                 // должен сделать запрос на GraphQL сервер
@@ -76,7 +76,7 @@ function makeClient() {
         },
       },
     }),
-    // connectToDevTools: true,
+    connectToDevTools: true,
     link: authLink.concat(httpLink),
   })
 }


### PR DESCRIPTION
After a custom behaviour was added to the "getUsers" cached field, the bug appears. Fixed with defining additional keysArgs.